### PR TITLE
Fix: Stuck in loop when TAB_URL for membership is empty sometimes

### DIFF
--- a/live-dl
+++ b/live-dl
@@ -411,6 +411,8 @@ function func_check_membership() {
       retry_membership=0
     else
       __debug "LiveDL can detect member-only posts but can not found any VideoID."
+      # Reset counter
+      retry_membership=0
     fi
   else
     # Retry and loop
@@ -473,7 +475,7 @@ function func_check_state() {
     if [ $retry_membership -ge 1 ]; then
       while [ $retry_membership -le 4 ]; do
         func_check_membership
-        # Break loop if got value $_VIDEO_ID
+        # Break loop if got member-only posts
         if [[ $retry_membership == "0" ]]; then
           break
         fi


### PR DESCRIPTION
TAB_URL for membership detection is empty sometimes, and stucks in for loop until it get five empty urls.

logs:
```
[Sun Feb 20 18:46:56 CST 2022] DEBUG: start func_check_state
[Sun Feb 20 18:46:56 CST 2022] DEBUG: Cookies using: ./config/cookies_membership.txt
[Sun Feb 20 18:46:56 CST 2022] DEBUG: Tab Membership check: 
[Sun Feb 20 18:46:56 CST 2022] Retrying to detect member only stream. 1 time(s) 
[Sun Feb 20 18:47:17 CST 2022] DEBUG: Tab Membership check: /c/%E6%B5%A0MizukiChannel/membership
[Sun Feb 20 18:47:17 CST 2022] DEBUG: LiveDL can detect member-only posts but can not found any VideoID.
[Sun Feb 20 18:47:17 CST 2022] DEBUG: Tab Membership check: 
[Sun Feb 20 18:47:17 CST 2022] Retrying to detect member only stream. 2 time(s) 
[Sun Feb 20 18:47:38 CST 2022] DEBUG: Tab Membership check: /c/%E6%B5%A0MizukiChannel/membership
[Sun Feb 20 18:47:38 CST 2022] DEBUG: LiveDL can detect member-only posts but can not found any VideoID.
[Sun Feb 20 18:47:38 CST 2022] DEBUG: Tab Membership check: /c/%E6%B5%A0MizukiChannel/membership
[Sun Feb 20 18:47:38 CST 2022] DEBUG: LiveDL can detect member-only posts but can not found any VideoID.
[Sun Feb 20 18:47:39 CST 2022] DEBUG: Tab Membership check: 
[Sun Feb 20 18:47:39 CST 2022] Retrying to detect member only stream. 3 time(s) 
[Sun Feb 20 18:47:59 CST 2022] DEBUG: Tab Membership check: /c/%E6%B5%A0MizukiChannel/membership
[Sun Feb 20 18:48:00 CST 2022] DEBUG: LiveDL can detect member-only posts but can not found any VideoID.
[Sun Feb 20 18:48:00 CST 2022] DEBUG: Tab Membership check: 
[Sun Feb 20 18:48:00 CST 2022] Retrying to detect member only stream. 4 time(s) 
[Sun Feb 20 18:48:20 CST 2022] DEBUG: Tab Membership check: /c/%E6%B5%A0MizukiChannel/membership
[Sun Feb 20 18:48:20 CST 2022] DEBUG: LiveDL can detect member-only posts but can not found any VideoID.
[Sun Feb 20 18:48:21 CST 2022] DEBUG: Tab Membership check: /c/%E6%B5%A0MizukiChannel/membership
[Sun Feb 20 18:48:21 CST 2022] DEBUG: LiveDL can detect member-only posts but can not found any VideoID.
[Sun Feb 20 18:48:21 CST 2022] DEBUG: Tab Membership check: /c/%E6%B5%A0MizukiChannel/membership
[Sun Feb 20 18:48:21 CST 2022] DEBUG: LiveDL can detect member-only posts but can not found any VideoID.
[Sun Feb 20 18:48:22 CST 2022] DEBUG: Tab Membership check: /c/%E6%B5%A0MizukiChannel/membership
[Sun Feb 20 18:48:22 CST 2022] DEBUG: LiveDL can detect member-only posts but can not found any VideoID.
[Sun Feb 20 18:48:22 CST 2022] DEBUG: Tab Membership check: /c/%E6%B5%A0MizukiChannel/membership
[Sun Feb 20 18:48:22 CST 2022] DEBUG: LiveDL can detect member-only posts but can not found any VideoID.
[Sun Feb 20 18:48:23 CST 2022] DEBUG: Tab Membership check: /c/%E6%B5%A0MizukiChannel/membership
[Sun Feb 20 18:48:23 CST 2022] DEBUG: LiveDL can detect member-only posts but can not found any VideoID.
[Sun Feb 20 18:48:23 CST 2022] DEBUG: Tab Membership check: /c/%E6%B5%A0MizukiChannel/membership
[Sun Feb 20 18:48:23 CST 2022] DEBUG: LiveDL can detect member-only posts but can not found any VideoID.
[Sun Feb 20 18:48:24 CST 2022] DEBUG: Tab Membership check: /c/%E6%B5%A0MizukiChannel/membership
[Sun Feb 20 18:48:24 CST 2022] DEBUG: LiveDL can detect member-only posts but can not found any VideoID.
[Sun Feb 20 18:48:24 CST 2022] DEBUG: Tab Membership check: /c/%E6%B5%A0MizukiChannel/membership
[Sun Feb 20 18:48:24 CST 2022] DEBUG: LiveDL can detect member-only posts but can not found any VideoID.
[Sun Feb 20 18:48:25 CST 2022] DEBUG: Tab Membership check: /c/%E6%B5%A0MizukiChannel/membership
[Sun Feb 20 18:48:25 CST 2022] DEBUG: LiveDL can detect member-only posts but can not found any VideoID.
[Sun Feb 20 18:48:25 CST 2022] DEBUG: Tab Membership check: /c/%E6%B5%A0MizukiChannel/membership
[Sun Feb 20 18:48:25 CST 2022] DEBUG: LiveDL can detect member-only posts but can not found any VideoID.
[Sun Feb 20 18:48:26 CST 2022] DEBUG: Tab Membership check: 
[Sun Feb 20 18:48:26 CST 2022] Retrying to detect member only stream. 5 time(s) 
[Sun Feb 20 18:48:46 CST 2022] Sending Discord notification...
```