### PR TITLE
Fix: missing fi

### DIFF
--- a/live-dl
+++ b/live-dl
@@ -1685,6 +1685,7 @@ function func_finalize_download() {
       else
         curl -s "$THUMBNAIL_CALC" -o "$OUTPUT_PATH.jpg"
       fi
+    fi
   fi
 
   if [ $SKIP_METADATA == "false" ]; then


### PR DESCRIPTION
**Describe the bug**
missing fi statement

**To Reproduce**
1. Script run `live-dl ......`
2. The error
```
/usr/src/app/live-dl: line 1775: syntax error near unexpected token `}'
/usr/src/app/live-dl: line 1775: `}'
```

**Desktop (please complete the following information):**
 - OS: Docker @ Synology NAS
 - Version: latest